### PR TITLE
Build modular hei-seti toolkit with CLI, Docker, and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main, work, master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+      - name: Lint with ruff
+        run: ruff check .
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+.env
+.venv
+build/
+dist/
+*.log
+.pytest_cache/
+.cache/
+.coverage
+htmlcov/
+.DS_Store
+.eggs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# Autonomous Agent Roles
+
+This repository is structured around five cooperating agents. Each agent can be run manually
+(via the CLI modules) or orchestrated by an automation framework.
+
+## Ingestion Agent
+- **Entry point**: `hei_seti.data_sources.HeasarcFetcher`
+- **Inputs**: catalog names, HEASARC TAP endpoint, optional filters.
+- **Outputs**: unified `pandas.DataFrame` with provenance column `_source_table`.
+- **Notes**: Implements retry-aware queries, logs record counts, and persists raw tables
+  under `data/`.
+
+## Feature Agent
+- **Entry point**: `hei_seti.features.FeatureBuilder`
+- **Inputs**: raw catalog dataframe, configuration for column mappings.
+- **Outputs**: normalized feature table with standardized columns
+  (`flux`, `hardness`, `period`, `bh_mass`, `var_ratio`).
+- **Notes**: Performs type coercion, handles missing values, logs summary statistics.
+
+## Heuristic Agent
+- **Entry point**: `hei_seti.heuristics.KBarrowCalculator`
+- **Inputs**: engineered features plus optional distance or variability measurements.
+- **Outputs**: Kardashev (continuous) and Barrow (ordinal) estimates for each source.
+- **Notes**: Encapsulates domain heuristics. Emits logging metadata for every computation
+  batch to support audit trails.
+
+## Anomaly Agent
+- **Entry point**: `hei_seti.anomaly.AnomalyModel`
+- **Inputs**: feature table with Kardashev/Barrow metrics, contamination rate, random seed.
+- **Outputs**: trained Isolation Forest model plus anomaly scores for candidate ranking.
+- **Notes**: Supports serialization with `joblib` and logs fit/score diagnostics.
+
+## Visualization Agent
+- **Entry point**: `hei_seti.cli` (`plot` command)
+- **Inputs**: feature table, candidate shortlist, Matplotlib configuration.
+- **Outputs**: `results/kb_space.png` plot summarizing K×B landscape.
+- **Notes**: Keeps plotting optional to maintain compatibility with headless workflows.
+
+## Agent Workflow
+
+```mermaid
+graph LR
+    A[Ingestion Agent] --> B[Feature Agent]
+    B --> C[Heuristic Agent]
+    C --> D[Anomaly Agent]
+    D --> E[Visualization Agent]
+    C --> F[(Research Notebooks)]
+```
+
+Each agent records structured logs defined in `src/hei_seti/logging_conf.py`. When executed
+through the CLI, the default logging configuration uses JSON lines, simplifying downstream
+log aggregation.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,112 @@
-# Hei-seti-High-energy-Astrobiology-Toolkit-vidal-2011-
-Blackholes and intelligence
+# hei-seti: High-Energy Astrobiology Toolkit
+
+Operational toolkit inspired by Vidal (2011) *Black Holes: Attractors for Intelligence?*.
+It provides a reproducible pipeline to retrieve X-ray binary (XRB) data, engineer
+Kardashev–Barrow metrics, and highlight anomalous systems that could merit follow-up.
+
+> **Disclaimer**: This repository is research-oriented. It does not claim detections of
+> technosignatures; it provides tools to explore the hypothesis with rigor and transparency.
+
+## Architecture at a glance
+
+```mermaid
+graph TD
+    A[HEASARC / BlackCAT Catalogs] -->|astroquery| B(Data Ingestion Agent)
+    B --> C[Feature Agent]
+    C --> D[Heuristic Agent]
+    D --> E[Anomaly Agent]
+    E --> F[Visualization Agent]
+    D -->|K, B metrics| G[Researcher]
+    F --> G
+```
+
+## Key capabilities
+
+- Fetches XRB metadata from HEASARC catalogs using `astroquery`.
+- Normalizes heterogeneous catalog fields into a consistent feature table.
+- Computes Kardashev (K) and Barrow (B) scale proxies following Vidal (2011) heuristics.
+- Trains an Isolation Forest anomaly detector to surface outliers in K×B space.
+- Offers a CLI and modular Python API with structured logging for reproducibility.
+- Ships with Docker and pytest-based CI for easy deployment and validation.
+
+## Installation
+
+### From source
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install .
+```
+
+For development work:
+
+```bash
+python -m pip install -e .[dev]
+```
+
+### Docker
+
+Build and run within a container that includes system dependencies for `astropy`,
+`astroquery`, `scikit-learn`, and `lightkurve`:
+
+```bash
+docker compose -f docker/docker-compose.yaml build
+# Example: fetch and featurize data inside the container
+mkdir -p data models results
+docker compose -f docker/docker-compose.yaml run --rm hei-seti fetch
+```
+
+The compose file mounts `./data`, `./models`, and `./results` into the container for
+artifact persistence.
+
+## Quickstart CLI
+
+```bash
+# Step 1: fetch multiple HEASARC tables
+hei-seti fetch --tables xrbcatalog hmxbcat2 lmxbcatalog
+
+# Step 2: engineer features and Kardashev/Barrow proxies
+hei-seti featurize --in data/raw.parquet --out data/features.parquet
+
+# Step 3: train anomaly detector and score candidates
+hei-seti train --features data/features.parquet --out models/iforest.joblib
+hei-seti score --model models/iforest.joblib --top 25 --out results/candidates.csv
+
+# Optional: visualize the KB space
+hei-seti plot --features data/features.parquet --candidates results/candidates.csv
+```
+
+## Kardashev & Barrow scales
+
+- **Kardashev**: continuous interpolation following Sagan `(log10 P - 6)/10` where `P` is
+  total power in watts. When distances are unknown, the toolkit uses scaled flux as a
+  proxy to maintain comparability across sources.
+- **Barrow**: ordinal scale capturing inward manipulation capabilities. Observables such as
+  estimated black-hole mass, hardness variability, and flux excursions map to proxies for
+  Barrow levels `BI` through `Bω`.
+
+## Configuration
+
+Default configuration is stored in `configs/default.yaml`. Customize catalogs, feature
+columns, and anomaly detector hyperparameters by providing your own YAML file and pointing
+pipeline or CLI commands to it via the `--config` option.
+
+## Development workflow
+
+1. Install dev dependencies: `pip install -e .[dev]`
+2. Run linters and tests: `ruff check .` and `pytest`
+3. Submit pull requests with passing CI. GitHub Actions workflow ensures style and tests run
+   for every push/PR.
+
+## Citation
+
+If this toolkit contributes to your research, please cite:
+
+```
+Vidal, C. (2011). Black Holes: Attractors for Intelligence?. Journal of Consciousness Studies, 18(2), 3-4.
+```
+
+## License
+
+MIT License © atorsvn
+

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,0 +1,23 @@
+fetch:
+  heasarc_tables:
+    - xrbcatalog
+    - hmxbcat2
+    - lmxbcatalog
+  maxrec: 20000
+
+features:
+  flux_cols: ["flux", "fx", "flux_max", "flux_min"]
+  hardness_cols: ["hardness", "hr1", "hr2"]
+  period_cols: ["p_orb", "period", "porb"]
+  bh_mass_cols: ["mbh", "bhmass", "mass_bh"]
+
+heuristics:
+  distance_col: "distance_kpc"
+  flux_unit: "erg cm-2 s-1"
+
+anomaly:
+  contamination: 0.05
+  random_state: 42
+
+logging:
+  config: "configs/logging.yaml"

--- a/configs/logging.yaml
+++ b/configs/logging.yaml
@@ -1,0 +1,19 @@
+version: 1
+formatters:
+  json:
+    (): hei_seti.logging_conf.JsonFormatter
+    fmt: "%(timestamp)s %(levelname)s %(name)s %(message)s"
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: json
+    level: INFO
+    stream: ext://sys.stdout
+loggers:
+  hei_seti:
+    level: INFO
+    handlers: [console]
+    propagate: False
+root:
+  level: INFO
+  handlers: [console]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python -m venv $VIRTUAL_ENV \
+    && $VIRTUAL_ENV/bin/pip install --upgrade pip setuptools wheel
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY pyproject.toml requirements.txt README.md LICENSE /app/
+COPY src /app/src
+COPY configs /app/configs
+COPY tests /app/tests
+COPY AGENTS.md /app/AGENTS.md
+
+RUN pip install -e .[dev]
+
+ENTRYPOINT ["hei-seti"]
+CMD ["--help"]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  hei-seti:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: hei-seti:latest
+    volumes:
+      - ../data:/app/data
+      - ../models:/app/models
+      - ../results:/app/results
+    environment:
+      - PYTHONUNBUFFERED=1
+    entrypoint: ["hei-seti"]
+    working_dir: /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hei-seti"
+version = "0.1.0"
+description = "High-Energy Astrobiology toolkit for Kardashev-Barrow anomaly searches"
+readme = "README.md"
+authors = [{name = "Lucky + Monday"}]
+license = {file = "LICENSE"}
+requires-python = ">=3.10"
+dependencies = [
+  "numpy>=1.26",
+  "pandas>=2.2",
+  "scikit-learn>=1.4",
+  "scipy>=1.12",
+  "matplotlib>=3.8",
+  "pyyaml>=6.0",
+  "pydantic>=2.7",
+  "astropy>=6.0",
+  "astroquery>=0.4.7",
+  "lightkurve>=2.4; python_version < '3.13'",
+  "pyarrow>=17.0.0",
+  "tqdm>=4.66",
+  "joblib>=1.3"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "pytest-cov>=4.1",
+  "ruff>=0.4",
+  "black>=24.3"
+]
+
+[project.scripts]
+hei-seti = "hei_seti.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "-ra --cov=hei_seti --cov-report=term-missing"
+minversion = "8.0"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.black]
+line-length = 100
+target-version = ['py310']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+numpy>=1.26
+pandas>=2.2
+scikit-learn>=1.4
+scipy>=1.12
+matplotlib>=3.8
+pyyaml>=6.0
+pydantic>=2.7
+astropy>=6.0
+astroquery>=0.4.7
+lightkurve>=2.4; python_version<'3.13'
+pyarrow>=17.0.0
+tqdm>=4.66
+joblib>=1.3

--- a/src/hei_seti/__init__.py
+++ b/src/hei_seti/__init__.py
@@ -1,0 +1,24 @@
+"""High-Energy Astrobiology Toolkit."""
+
+from importlib import metadata
+
+from . import anomaly, data_sources, features, heuristics, pipeline, scales
+
+__all__ = [
+    "anomaly",
+    "data_sources",
+    "features",
+    "heuristics",
+    "pipeline",
+    "scales",
+    "__version__",
+]
+
+
+def __getattr__(name: str):
+    if name == "__version__":
+        try:
+            return metadata.version("hei-seti")
+        except metadata.PackageNotFoundError:  # pragma: no cover - during development
+            return "0.0.0"
+    raise AttributeError(name)

--- a/src/hei_seti/anomaly.py
+++ b/src/hei_seti/anomaly.py
@@ -1,0 +1,68 @@
+"""Anomaly detection for Kardashev–Barrow feature space."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import IsolationForest
+
+LOGGER = logging.getLogger(__name__)
+
+FEATURE_COLUMNS = ["flux", "hardness", "period", "bh_mass", "var_ratio", "K", "B"]
+
+
+@dataclass(slots=True)
+class AnomalyModel:
+    """Wrapper around scikit-learn IsolationForest with structured logging."""
+
+    contamination: float = 0.05
+    random_state: int | None = None
+    _model: IsolationForest | None = field(default=None, init=False, repr=False)
+
+    def _prepare(self, df: pd.DataFrame) -> np.ndarray:
+        missing = [column for column in FEATURE_COLUMNS if column not in df]
+        if missing:
+            raise KeyError(f"Missing feature columns: {missing}")
+        matrix = df[FEATURE_COLUMNS].astype(float).to_numpy()
+        return np.nan_to_num(matrix, nan=0.0, posinf=0.0, neginf=0.0)
+
+    def fit(self, df: pd.DataFrame) -> IsolationForest:
+        matrix = self._prepare(df)
+        LOGGER.info(
+            "anomaly.fit.start",
+            extra={"extra_data": {"rows": len(df), "contamination": self.contamination}},
+        )
+        self._model = IsolationForest(
+            contamination=self.contamination,
+            random_state=self.random_state,
+        )
+        self._model.fit(matrix)
+        LOGGER.info(
+            "anomaly.fit.finish",
+            extra={"extra_data": {"estimators": len(self._model.estimators_)}}
+        )
+        return self._model
+
+    def score(self, df: pd.DataFrame) -> pd.Series:
+        if self._model is None:
+            raise RuntimeError("Model has not been fit")
+        matrix = self._prepare(df)
+        raw_scores = -self._model.score_samples(matrix)
+        LOGGER.info(
+            "anomaly.score",
+            extra={"extra_data": {"rows": len(df), "score_mean": float(np.mean(raw_scores))}},
+        )
+        return pd.Series(raw_scores, index=df.index, name="anomaly")
+
+    def rank(self, df: pd.DataFrame, top: int = 50) -> pd.DataFrame:
+        scores = self.score(df)
+        ranked = df.copy()
+        ranked["anomaly"] = scores
+        ranked["rank"] = ranked["anomaly"].rank(ascending=False, method="first")
+        LOGGER.info(
+            "anomaly.rank",
+            extra={"extra_data": {"rows": len(df), "top": top}},
+        )
+        return ranked.sort_values("anomaly", ascending=False).head(top)

--- a/src/hei_seti/cli.py
+++ b/src/hei_seti/cli.py
@@ -1,0 +1,104 @@
+"""Command line interface for the HEI-SETI pipeline."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from .logging_conf import setup_logging
+from .pipeline import Pipeline
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hei-seti", description="High-Energy Astrobiology toolkit")
+    parser.add_argument("--config", default="configs/default.yaml", help="Path to pipeline config YAML")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    fetch_parser = subparsers.add_parser("fetch", help="Fetch HEASARC tables")
+    fetch_parser.add_argument("--tables", nargs="*", help="Override tables to fetch")
+    fetch_parser.add_argument("--output", default="data/raw.parquet")
+
+    featurize_parser = subparsers.add_parser("featurize", help="Engineer features and KB metrics")
+    featurize_parser.add_argument("--input", default="data/raw.parquet")
+    featurize_parser.add_argument("--output", default="data/features.parquet")
+
+    train_parser = subparsers.add_parser("train", help="Train the anomaly detector")
+    train_parser.add_argument("--input", default="data/features.parquet")
+    train_parser.add_argument("--model", default="models/iforest.joblib")
+
+    score_parser = subparsers.add_parser("score", help="Score and rank candidates")
+    score_parser.add_argument("--model", required=True)
+    score_parser.add_argument("--input", default="data/features.parquet")
+    score_parser.add_argument("--output", default="results/candidates.csv")
+    score_parser.add_argument("--top", type=int, default=50)
+
+    plot_parser = subparsers.add_parser("plot", help="Visualise KB space")
+    plot_parser.add_argument("--input", default="data/features.parquet")
+    plot_parser.add_argument("--candidates", default="results/candidates.csv")
+    plot_parser.add_argument("--output", default="results/kb_space.png")
+
+    return parser
+
+
+def _load_pipeline(config_path: str | Path) -> Pipeline:
+    setup_logging(None)
+    return Pipeline.from_yaml(config_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    pipeline = _load_pipeline(args.config)
+
+    if args.command == "fetch":
+        df = pipeline.fetch(tables=args.tables, output=args.output)
+        print(f"Fetched {len(df)} rows -> {args.output}")
+        return 0
+
+    if args.command == "featurize":
+        df = pipeline.featurize(input_path=args.input, output=args.output)
+        print(f"Featurized {len(df)} rows -> {args.output}")
+        return 0
+
+    if args.command == "train":
+        model_path = pipeline.train(input_path=args.input, model_path=args.model)
+        print(f"Model saved to {model_path}")
+        return 0
+
+    if args.command == "score":
+        scores = pipeline.score(
+            model_path=args.model,
+            input_path=args.input,
+            top=args.top,
+            output=args.output,
+        )
+        print(f"Wrote top {len(scores)} candidates -> {args.output}")
+        return 0
+
+    if args.command == "plot":
+        features = pd.read_parquet(args.input)
+        candidates = pd.read_csv(args.candidates) if Path(args.candidates).exists() else None
+        fig, ax = plt.subplots(figsize=(8, 6))
+        ax.scatter(features["K"], features["B"], alpha=0.3, label="catalogue")
+        if candidates is not None:
+            ax.scatter(candidates["K"], candidates["B"], marker="x", s=80, label="candidates")
+        ax.set_xlabel("Kardashev K")
+        ax.set_ylabel("Barrow level")
+        ax.set_title("K×B candidate landscape")
+        ax.legend()
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        fig.tight_layout()
+        fig.savefig(args.output)
+        print(f"Plot saved -> {args.output}")
+        return 0
+
+    parser.error("Unknown command")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/hei_seti/data_sources.py
+++ b/src/hei_seti/data_sources.py
@@ -1,0 +1,88 @@
+"""Data ingestion utilities for HEASARC catalogs."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+try:  # pragma: no cover - import guard for optional dependency
+    from astroquery.heasarc import Heasarc
+except ImportError as exc:  # pragma: no cover - surfaces during optional installs
+    Heasarc = None  # type: ignore
+    IMPORT_ERROR = exc
+else:  # pragma: no cover - this block not executed during unit tests
+    IMPORT_ERROR = None
+
+LOGGER = logging.getLogger(__name__)
+
+
+class HeasarcUnavailableError(RuntimeError):
+    """Raised when astroquery/Heasarc is not available."""
+
+
+@dataclass(slots=True)
+class HeasarcFetcher:
+    """Fetch catalogues from HEASARC with provenance-aware logging."""
+
+    maxrec: int = 20000
+    client: Heasarc | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.client is None:
+            if Heasarc is None:
+                raise HeasarcUnavailableError(
+                    "astroquery.heasarc.Heasarc is unavailable. Install astroquery to use"
+                    " network fetching."
+                ) from IMPORT_ERROR
+            self.client = Heasarc()
+        LOGGER.debug("Initialized HeasarcFetcher maxrec=%s", self.maxrec)
+
+    def query_table(self, table: str) -> pd.DataFrame:
+        """Query a HEASARC table using TAP and return a pandas DataFrame."""
+
+        LOGGER.info("fetch.start", extra={"extra_data": {"table": table}})
+        query = f"SELECT * FROM {table}"
+        result = self.client.query_tap(query, maxrec=self.maxrec)
+        df = result.to_table().to_pandas()
+        df["_source_table"] = table
+        LOGGER.info(
+            "fetch.finish",
+            extra={"extra_data": {"table": table, "rows": len(df)}},
+        )
+        return df
+
+    def fetch_many(self, tables: Iterable[str]) -> pd.DataFrame:
+        """Fetch multiple tables and concatenate them with provenance metadata."""
+
+        frames = []
+        for table in tables:
+            try:
+                frames.append(self.query_table(table))
+            except Exception as error:  # pragma: no cover - network error path
+                LOGGER.warning(
+                    "fetch.error",
+                    extra={"extra_data": {"table": table, "error": str(error)}},
+                )
+        if not frames:
+            raise RuntimeError("No tables were successfully fetched")
+        combined = pd.concat(frames, ignore_index=True)
+        LOGGER.info(
+            "fetch.concat",
+            extra={"extra_data": {"rows": len(combined), "tables": list(tables)}},
+        )
+        return combined
+
+    @staticmethod
+    def persist_dataframe(df: pd.DataFrame, path: str | Path) -> Path:
+        """Persist the dataframe to parquet with logging."""
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_parquet(path)
+        LOGGER.info(
+            "persist.finish", extra={"extra_data": {"path": str(path), "rows": len(df)}}
+        )
+        return path

--- a/src/hei_seti/features.py
+++ b/src/hei_seti/features.py
@@ -1,0 +1,50 @@
+"""Feature engineering from heterogeneous catalog columns."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class FeatureBuilder:
+    """Selects and standardises astrophysical features across catalogues."""
+
+    flux_cols: Iterable[str]
+    hardness_cols: Iterable[str]
+    period_cols: Iterable[str]
+    bh_mass_cols: Iterable[str]
+
+    def _first_valid(self, row: pd.Series, candidates: Iterable[str]) -> float:
+        for column in candidates:
+            if column in row and pd.notna(row[column]):
+                return float(row[column])
+        return float("nan")
+
+    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Create a clean feature matrix from a raw dataframe."""
+
+        LOGGER.info("features.start", extra={"extra_data": {"rows": len(df)}})
+        features = pd.DataFrame(index=df.index)
+        features["flux"] = df.apply(lambda r: self._first_valid(r, self.flux_cols), axis=1)
+        features["hardness"] = df.apply(lambda r: self._first_valid(r, self.hardness_cols), axis=1)
+        features["period"] = df.apply(lambda r: self._first_valid(r, self.period_cols), axis=1)
+        features["bh_mass"] = df.apply(lambda r: self._first_valid(r, self.bh_mass_cols), axis=1)
+
+        if {"flux_max", "flux_min"}.issubset(df.columns):
+            ratio = df["flux_max"] / df["flux_min"].replace({0: np.nan})
+            features["var_ratio"] = ratio.replace([np.inf, -np.inf], np.nan)
+        else:
+            features["var_ratio"] = np.nan
+
+        summary = {
+            column: float(np.nanmean(features[column].to_numpy()))
+            for column in features.columns
+        }
+        LOGGER.info("features.summary", extra={"extra_data": summary})
+        return features

--- a/src/hei_seti/heuristics.py
+++ b/src/hei_seti/heuristics.py
@@ -1,0 +1,94 @@
+"""Heuristic mappings for Kardashev and Barrow metrics."""
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from .scales import BarrowLevel, KardashevRating
+
+LOGGER = logging.getLogger(__name__)
+
+ERG_CM2_S_TO_W_M2 = 1e-3  # Rough conversion factor for flux units
+KPC_TO_METERS = 3.0856775814913673e19
+
+
+@dataclass(slots=True)
+class KBarrowCalculator:
+    """Compute Kardashev and Barrow proxies from engineered features."""
+
+    distance_col: str | None = None
+    flux_unit: str = "erg cm-2 s-1"
+
+    def estimate_power_watts(self, row: pd.Series) -> float:
+        """Estimate power output using flux and optional distance."""
+
+        flux = row.get("flux")
+        if flux is None or math.isnan(float(flux)):
+            return float("nan")
+
+        flux_wm2 = float(flux)
+        if self.flux_unit.lower().startswith("erg"):
+            flux_wm2 *= ERG_CM2_S_TO_W_M2
+
+        if self.distance_col and self.distance_col in row and not math.isnan(row[self.distance_col]):
+            distance_m = float(row[self.distance_col]) * KPC_TO_METERS * 1e3  # kpc to m
+            power = 4 * math.pi * (distance_m**2) * flux_wm2
+        else:
+            power = flux_wm2 * 1e20  # fallback scale factor when distance unknown
+        return power
+
+    def kardashev(self, row: pd.Series) -> float:
+        power = self.estimate_power_watts(row)
+        rating = KardashevRating(power).value()
+        LOGGER.debug("kardashev", extra={"extra_data": {"power": power, "rating": rating}})
+        return rating
+
+    def barrow(self, row: pd.Series) -> int:
+        mass = row.get("bh_mass")
+        variability = row.get("var_ratio")
+        hardness = row.get("hardness")
+
+        level = BarrowLevel.BIII
+        if pd.notna(mass) and float(mass) >= 10:
+            level = BarrowLevel.BV
+        if pd.notna(variability) and float(variability) > 100:
+            level = BarrowLevel.BV
+        if pd.notna(hardness) and float(hardness) > 5:
+            level = BarrowLevel.BIV
+        if pd.notna(mass) and float(mass) >= 20 and pd.notna(variability) and float(variability) > 200:
+            level = BarrowLevel.BOMEGA
+
+        LOGGER.debug(
+            "barrow",
+            extra={
+                "extra_data": {
+                    "mass": mass,
+                    "variability": variability,
+                    "hardness": hardness,
+                    "level": int(level),
+                }
+            },
+        )
+        return int(level)
+
+    def annotate(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Return dataframe with Kardashev and Barrow columns added."""
+
+        result = df.copy()
+        result["K"] = df.apply(self.kardashev, axis=1)
+        result["B"] = df.apply(self.barrow, axis=1)
+        LOGGER.info(
+            "heuristics.annotate",
+            extra={
+                "extra_data": {
+                    "rows": len(result),
+                    "k_mean": float(np.nanmean(result["K"].to_numpy())),
+                    "b_mean": float(np.nanmean(result["B"].to_numpy())),
+                }
+            },
+        )
+        return result

--- a/src/hei_seti/logging_conf.py
+++ b/src/hei_seti/logging_conf.py
@@ -1,0 +1,43 @@
+"""Logging helpers providing structured JSON output."""
+from __future__ import annotations
+
+import json
+import logging
+import logging.config
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class JsonFormatter(logging.Formatter):
+    """Minimal JSON formatter to avoid external dependencies."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - inherited docstring
+        payload: dict[str, Any] = {
+            "timestamp": datetime.utcfromtimestamp(record.created).isoformat() + "Z",
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.__dict__.get("extra_data"):
+            payload.update(record.__dict__["extra_data"])
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def setup_logging(config_path: str | Path | None = None) -> None:
+    """Configure logging from a YAML file or fallback to sane defaults."""
+
+    if config_path is not None and Path(config_path).exists():
+        with Path(config_path).open("r", encoding="utf-8") as stream:
+            config = yaml.safe_load(stream)
+            logging.config.dictConfig(config)
+            return
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )

--- a/src/hei_seti/pipeline.py
+++ b/src/hei_seti/pipeline.py
@@ -1,0 +1,127 @@
+"""End-to-end orchestration for the HEI-SETI workflow."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import yaml
+from joblib import dump, load
+
+from .anomaly import AnomalyModel
+from .data_sources import HeasarcFetcher
+from .features import FeatureBuilder
+from .heuristics import KBarrowCalculator
+from .logging_conf import setup_logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class Pipeline:
+    """High-level pipeline comprised of ingestion, feature, and anomaly stages."""
+
+    config: dict
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "Pipeline":
+        path = Path(path)
+        with path.open("r", encoding="utf-8") as stream:
+            config = yaml.safe_load(stream)
+        logging_config = config.get("logging", {}).get("config")
+        setup_logging(logging_config)
+        LOGGER.info("pipeline.init", extra={"extra_data": {"config": str(path)}})
+        return cls(config=config)
+
+    def fetch(self, tables: Iterable[str] | None = None, output: str | Path = "data/raw.parquet") -> pd.DataFrame:
+        cfg = self.config.get("fetch", {})
+        tables = list(tables or cfg.get("heasarc_tables", []))
+        fetcher = HeasarcFetcher(maxrec=cfg.get("maxrec", 20000))
+        dataframe = fetcher.fetch_many(tables)
+        fetcher.persist_dataframe(dataframe, output)
+        return dataframe
+
+    def featurize(
+        self,
+        dataframe: pd.DataFrame | None = None,
+        input_path: str | Path = "data/raw.parquet",
+        output: str | Path = "data/features.parquet",
+    ) -> pd.DataFrame:
+        if dataframe is None:
+            dataframe = pd.read_parquet(input_path)
+        cfg = self.config.get("features", {})
+        builder = FeatureBuilder(
+            flux_cols=cfg.get("flux_cols", []),
+            hardness_cols=cfg.get("hardness_cols", []),
+            period_cols=cfg.get("period_cols", []),
+            bh_mass_cols=cfg.get("bh_mass_cols", []),
+        )
+        features = builder.transform(dataframe)
+        heur_cfg = self.config.get("heuristics", {})
+        kb = KBarrowCalculator(
+            distance_col=heur_cfg.get("distance_col"),
+            flux_unit=heur_cfg.get("flux_unit", "erg cm-2 s-1"),
+        )
+        features = kb.annotate(features)
+        features["name"] = dataframe.get("name", dataframe.get("src_name", dataframe.index))
+        features["_source_table"] = dataframe.get("_source_table", "unknown")
+        Path(output).parent.mkdir(parents=True, exist_ok=True)
+        features.to_parquet(output)
+        LOGGER.info(
+            "pipeline.featurize",
+            extra={"extra_data": {"rows": len(features), "output": str(output)}},
+        )
+        return features
+
+    def train(
+        self,
+        features: pd.DataFrame | None = None,
+        input_path: str | Path = "data/features.parquet",
+        model_path: str | Path = "models/iforest.joblib",
+    ) -> Path:
+        if features is None:
+            features = pd.read_parquet(input_path)
+        cfg = self.config.get("anomaly", {})
+        model = AnomalyModel(
+            contamination=cfg.get("contamination", 0.05),
+            random_state=cfg.get("random_state"),
+        )
+        model.fit(features)
+        model_path = Path(model_path)
+        model_path.parent.mkdir(parents=True, exist_ok=True)
+        dump(model, model_path)
+        LOGGER.info(
+            "pipeline.train",
+            extra={"extra_data": {"rows": len(features), "model_path": str(model_path)}},
+        )
+        return model_path
+
+    def score(
+        self,
+        model_path: str | Path,
+        features: pd.DataFrame | None = None,
+        input_path: str | Path = "data/features.parquet",
+        top: int = 50,
+        output: str | Path | None = "results/candidates.csv",
+    ) -> pd.DataFrame:
+        if features is None:
+            features = pd.read_parquet(input_path)
+        model: AnomalyModel = load(model_path)
+        scores = model.rank(features, top=top)
+        if output is not None:
+            output_path = Path(output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            scores.to_csv(output_path, index=False)
+            LOGGER.info(
+                "pipeline.score",
+                extra={
+                    "extra_data": {
+                        "rows": len(features),
+                        "top": top,
+                        "output": str(output_path),
+                    }
+                },
+            )
+        return scores

--- a/src/hei_seti/scales.py
+++ b/src/hei_seti/scales.py
@@ -1,0 +1,58 @@
+"""Utilities for Kardashev and Barrow scales."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Iterable
+
+import numpy as np
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BarrowLevel(IntEnum):
+    """Enumerated Barrow levels following Vidal (2011)."""
+
+    BI = 1
+    BII = 2
+    BIII = 3
+    BIV = 4
+    BV = 5
+    BOMEGA = 6
+
+
+@dataclass(slots=True)
+class KardashevRating:
+    """Continuous Kardashev rating using Sagan interpolation."""
+
+    power_watts: float | None
+
+    def value(self) -> float:
+        """Return `(log10(P) - 6)/10` when P is positive, else NaN."""
+
+        if self.power_watts is None or self.power_watts <= 0:
+            LOGGER.debug("Invalid power_watts=%s for Kardashev calculation", self.power_watts)
+            return float("nan")
+        value = (np.log10(self.power_watts) - 6.0) / 10.0
+        LOGGER.debug("Computed Kardashev rating %.3f from power %.3e", value, self.power_watts)
+        return value
+
+
+def normalize_barrow_levels(levels: Iterable[int | float | BarrowLevel]) -> list[int]:
+    """Normalize a collection of barrow levels to integers.
+
+    Values outside the defined range are clipped to `[BI, BOMEGA]`.
+    """
+
+    normalized: list[int] = []
+    for level in levels:
+        try:
+            numeric = int(level)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            LOGGER.debug("Encountered invalid Barrow level %s", level)
+            numeric = BarrowLevel.BI
+        numeric = max(BarrowLevel.BI, min(BarrowLevel.BOMEGA, numeric))
+        normalized.append(int(numeric))
+    LOGGER.debug("Normalized Barrow levels: %s", normalized)
+    return normalized

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from hei_seti import cli
+
+
+class StubPipeline:
+    def __init__(self):
+        self.fetch_args = None
+        self.featurize_args = None
+        self.train_args = None
+        self.score_args = None
+
+    def fetch(self, tables=None, output=None):
+        self.fetch_args = (tables, output)
+        return pd.DataFrame({"value": [1, 2]})
+
+    def featurize(self, input_path=None, output=None, dataframe=None):
+        self.featurize_args = (input_path, output)
+        return pd.DataFrame({"K": [0.1, 0.2], "B": [1, 2]})
+
+    def train(self, input_path=None, model_path=None, features=None):
+        self.train_args = (input_path, model_path)
+        return Path(model_path)
+
+    def score(self, model_path=None, input_path=None, top=50, output=None, features=None):
+        self.score_args = (model_path, input_path, top, output)
+        return pd.DataFrame({"K": [0.1], "B": [2], "anomaly": [0.5]})
+
+
+def test_cli_fetch(monkeypatch, tmp_path, capsys):
+    stub = StubPipeline()
+    monkeypatch.setattr(cli, "_load_pipeline", lambda _: stub)
+    output = tmp_path / "raw.parquet"
+    exit_code = cli.main(["--config", "configs/default.yaml", "fetch", "--output", str(output), "--tables", "a", "b"])
+    assert exit_code == 0
+    captured = capsys.readouterr().out
+    assert "Fetched" in captured
+    assert stub.fetch_args == (["a", "b"], str(output))
+
+
+def test_cli_featurize_and_train(monkeypatch, tmp_path, capsys):
+    stub = StubPipeline()
+    monkeypatch.setattr(cli, "_load_pipeline", lambda _: stub)
+    features_path = tmp_path / "features.parquet"
+    model_path = tmp_path / "model.joblib"
+    exit_code = cli.main(["--config", "configs/default.yaml", "featurize", "--input", "data/raw.parquet", "--output", str(features_path)])
+    assert exit_code == 0
+    exit_code = cli.main(["--config", "configs/default.yaml", "train", "--input", str(features_path), "--model", str(model_path)])
+    assert exit_code == 0
+    captured = capsys.readouterr().out
+    assert "Model saved" in captured
+    assert stub.train_args == (str(features_path), str(model_path))
+
+
+def test_cli_score_and_plot(monkeypatch, tmp_path, capsys):
+    stub = StubPipeline()
+    monkeypatch.setattr(cli, "_load_pipeline", lambda _: stub)
+
+    features_path = tmp_path / "features.parquet"
+    candidates_path = tmp_path / "candidates.csv"
+    plot_path = tmp_path / "kb.png"
+
+    pd.DataFrame({"K": [0.1, 0.2], "B": [1, 2], "anomaly": [0.3, 0.4]}).to_parquet(features_path)
+    pd.DataFrame({"K": [0.2], "B": [2], "anomaly": [0.4]}).to_csv(candidates_path, index=False)
+
+    exit_code = cli.main([
+        "--config",
+        "configs/default.yaml",
+        "score",
+        "--model",
+        str(tmp_path / "model.joblib"),
+        "--input",
+        str(features_path),
+        "--output",
+        str(candidates_path),
+        "--top",
+        "1",
+    ])
+    assert exit_code == 0
+
+    exit_code = cli.main([
+        "--config",
+        "configs/default.yaml",
+        "plot",
+        "--input",
+        str(features_path),
+        "--candidates",
+        str(candidates_path),
+        "--output",
+        str(plot_path),
+    ])
+    assert exit_code == 0
+    assert plot_path.exists()
+    captured = capsys.readouterr().out
+    assert "Plot saved" in captured

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from hei_seti.data_sources import HeasarcFetcher
+
+
+@dataclass
+class DummyResult:
+    table_name: str
+
+    def to_table(self):
+        class _Table:
+            def __init__(self, table_name: str):
+                self._table_name = table_name
+
+            def to_pandas(self) -> pd.DataFrame:
+                return pd.DataFrame({"name": ["src"], "flux": [1.0], "table": [self._table_name]})
+
+        return _Table(self.table_name)
+
+
+class DummyClient:
+    def __init__(self):
+        self.queries: list[str] = []
+
+    def query_tap(self, query: str, maxrec: int):
+        self.queries.append(query)
+        table_name = query.split()[-1]
+        return DummyResult(table_name)
+
+
+def test_fetch_many_concatenates_tables(tmp_path):
+    fetcher = HeasarcFetcher(maxrec=10, client=DummyClient())
+    df = fetcher.fetch_many(["table1", "table2"])
+    assert len(df) == 2
+    assert set(df["_source_table"]) == {"table1", "table2"}
+    out = tmp_path / "raw.parquet"
+    path = fetcher.persist_dataframe(df, out)
+    assert path.exists()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+from hei_seti.features import FeatureBuilder
+
+
+def build_df():
+    return pd.DataFrame(
+        {
+            "flux": [1.0, None],
+            "fx": [None, 2.0],
+            "flux_max": [4.0, 10.0],
+            "flux_min": [1.0, 2.0],
+            "hardness": [0.5, None],
+            "hr1": [None, 1.2],
+            "period": [10.0, None],
+            "porb": [None, 5.0],
+            "mbh": [7.0, None],
+            "bhmass": [None, 12.0],
+        }
+    )
+
+
+def test_feature_builder_selects_first_valid_values():
+    df = build_df()
+    builder = FeatureBuilder(
+        flux_cols=["flux", "fx"],
+        hardness_cols=["hardness", "hr1"],
+        period_cols=["period", "porb"],
+        bh_mass_cols=["mbh", "bhmass"],
+    )
+    features = builder.transform(df)
+    assert features.loc[0, "flux"] == 1.0
+    assert features.loc[1, "flux"] == 2.0
+    assert features.loc[1, "hardness"] == 1.2
+    assert features.loc[1, "period"] == 5.0
+    assert features.loc[1, "bh_mass"] == 12.0
+    assert features.loc[1, "var_ratio"] == 5.0

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -1,0 +1,21 @@
+import math
+
+import pandas as pd
+
+from hei_seti.heuristics import KBarrowCalculator
+
+
+def test_kardashev_uses_flux_and_distance():
+    calc = KBarrowCalculator(distance_col="distance", flux_unit="erg cm-2 s-1")
+    row = pd.Series({"flux": 1e-9, "distance": 5})
+    power = calc.estimate_power_watts(row)
+    assert power > 0
+    rating = calc.kardashev(row)
+    assert not math.isnan(rating)
+
+
+def test_barrow_levels_increase_with_mass_and_variability():
+    calc = KBarrowCalculator()
+    low = calc.barrow(pd.Series({"bh_mass": 5, "var_ratio": 10, "hardness": 1}))
+    high = calc.barrow(pd.Series({"bh_mass": 25, "var_ratio": 400, "hardness": 8}))
+    assert high > low

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,52 @@
+import json
+import logging
+
+from hei_seti import __version__
+from hei_seti.logging_conf import JsonFormatter, setup_logging
+from hei_seti.pipeline import Pipeline
+
+
+def test_json_formatter_emits_expected_keys():
+    formatter = JsonFormatter()
+    record = logging.LogRecord("test", logging.INFO, __file__, 10, "hello", args=(), exc_info=None)
+    payload = json.loads(formatter.format(record))
+    assert payload["level"] == "INFO"
+    assert payload["message"] == "hello"
+
+
+def test_setup_logging_from_yaml(tmp_path):
+    config_path = tmp_path / "logging.yaml"
+    config_path.write_text(
+        """
+version: 1
+formatters:
+  json:
+    (): hei_seti.logging_conf.JsonFormatter
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: json
+    level: INFO
+    stream: ext://sys.stdout
+root:
+  level: INFO
+  handlers: [console]
+""",
+        encoding="utf-8",
+    )
+    setup_logging(config_path)
+    logger = logging.getLogger("hei_seti.tests")
+    logger.info("configured")
+
+
+def test_pipeline_from_yaml_uses_default_config():
+    pipeline = Pipeline.from_yaml("configs/default.yaml")
+    assert "fetch" in pipeline.config
+    assert isinstance(__version__, str)
+
+
+def test_setup_logging_basic_config():
+    setup_logging(None)
+    logger = logging.getLogger("hei_seti.sample")
+    logger.info("message")
+    assert logging.getLogger().handlers

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import pandas as pd
+
+from hei_seti.pipeline import Pipeline
+
+
+def sample_config(tmp_path: Path) -> dict:
+    return {
+        "features": {
+            "flux_cols": ["flux", "fx"],
+            "hardness_cols": ["hardness"],
+            "period_cols": ["period"],
+            "bh_mass_cols": ["bh_mass"],
+        },
+        "heuristics": {
+            "distance_col": None,
+            "flux_unit": "erg cm-2 s-1",
+        },
+        "anomaly": {
+            "contamination": 0.2,
+            "random_state": 0,
+        },
+    }
+
+
+def raw_dataframe() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "flux": [1e-9, 2e-9, 3e-9, 4e-9],
+            "hardness": [1.0, 2.0, 1.5, 3.5],
+            "period": [10, 20, 30, 40],
+            "bh_mass": [5, 8, 15, 30],
+            "var_ratio": [5, 10, 200, 300],
+            "name": ["A", "B", "C", "D"],
+            "_source_table": ["t1"] * 4,
+        }
+    )
+
+
+def test_pipeline_training_and_scoring(tmp_path):
+    pipeline = Pipeline(config=sample_config(tmp_path))
+    raw = raw_dataframe()
+    features_path = tmp_path / "features.parquet"
+    feats = pipeline.featurize(dataframe=raw, output=features_path)
+    assert features_path.exists()
+    model_path = tmp_path / "model.joblib"
+    pipeline.train(features=feats, model_path=model_path)
+    assert model_path.exists()
+    output_path = tmp_path / "candidates.csv"
+    scored = pipeline.score(model_path=model_path, features=feats, top=2, output=output_path)
+    assert output_path.exists()
+    assert len(scored) == 2
+    assert {"anomaly", "rank"}.issubset(scored.columns)

--- a/tests/test_scales.py
+++ b/tests/test_scales.py
@@ -1,0 +1,18 @@
+import math
+
+from hei_seti.scales import BarrowLevel, KardashevRating, normalize_barrow_levels
+
+
+def test_kardashev_positive_power():
+    rating = KardashevRating(1e16).value()
+    assert math.isclose(rating, (math.log10(1e16) - 6) / 10)
+
+
+def test_kardashev_non_positive_power_returns_nan():
+    assert math.isnan(KardashevRating(-1).value())
+    assert math.isnan(KardashevRating(None).value())
+
+
+def test_normalize_barrow_levels_clips_values():
+    values = normalize_barrow_levels([BarrowLevel.BII, 99, -1, "3"])
+    assert values == [BarrowLevel.BII, BarrowLevel.BOMEGA, BarrowLevel.BI, BarrowLevel.BIII]


### PR DESCRIPTION
## Summary
- document the Kardashev–Barrow workflow, quickstart, and agent responsibilities in the README and AGENTS guides
- implement an installable `hei_seti` package with ingestion, feature engineering, heuristics, anomaly detection, logging helpers, pipeline orchestration, and a multi-command CLI
- add reproducibility scaffolding including YAML configs, Docker assets, packaging metadata, GitHub Actions CI, and a pytest suite with CLI/data-source integration tests

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc7e9d6648832d9cf6ed853fe39ebe